### PR TITLE
Fix potential score weighting

### DIFF
--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -103,11 +103,10 @@ def calculate_potential_score(player_row: pd.Series,
     else:
         age_factor = (max_age - age) * weights['age_factor']
     
-    # Calculate progressive total
-    prog_total = player_row['progressive_carries'] + player_row['progressive_passes']
-    
+    # Apply separate weights for carries and passes
     score = (
-        prog_total * weights['progressive_carries'] +
+        player_row['progressive_carries'] * weights['progressive_carries'] +
+        player_row['progressive_passes'] * weights['progressive_passes'] +
         player_row['minutes'] * weights['minutes'] +
         age_factor +
         player_row['expected_goals'] * weights['expected_goals'] +

--- a/tests/test_utils_potential_score.py
+++ b/tests/test_utils_potential_score.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import pytest
+
+from analysis.utils import calculate_potential_score
+
+
+def test_calculate_potential_score_separate_weights():
+    player = pd.Series(
+        {
+            "age": 20,
+            "goals_per_90": 0,
+            "assists_per_90": 0,
+            "progressive_carries": 10,
+            "progressive_passes": 5,
+            "expected_goals": 2,
+            "expected_assists": 1,
+            "minutes": 1000,
+        }
+    )
+
+    score = calculate_potential_score(player)
+
+    # 10*0.05 + 5*0.02 + 1000*0.002 + (23-20)*10 + 2*5 + 1*5 = 47.6
+    assert score == pytest.approx(47.6)
+


### PR DESCRIPTION
## Summary
- correct potential score calculation to weigh progressive carries and passes independently
- add unit test for `calculate_potential_score`

## Testing
- `python -m pytest tests/test_utils_potential_score.py`
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'api.main_api')*

------
https://chatgpt.com/codex/tasks/task_e_689590f789208330bfee82cce4cc62d9